### PR TITLE
完善 relative2absolute() 对 baseId 出现相对路径的处理

### DIFF
--- a/src/esl.js
+++ b/src/esl.js
@@ -1401,42 +1401,33 @@ var esl;
      * @return {string} 绝对id
      */
     function relative2absolute(id, baseId) {
-        if (id.indexOf('.') === 0) {
-            var basePath = baseId.split('/');
-            var namePath = id.split('/');
-            var baseLen = basePath.length - 1;
-            var nameLen = namePath.length;
-            var cutBaseTerms = 0;
-            var cutNameTerms = 0;
-
-            /* eslint-disable block-scoped-var */
-            pathLoop: for (var i = 0; i < nameLen; i++) {
-                switch (namePath[i]) {
-                    case '..':
-                        if (cutBaseTerms < baseLen) {
-                            cutBaseTerms++;
-                            cutNameTerms++;
-                        }
-                        else {
-                            break pathLoop;
-                        }
-                        break;
-                    case '.':
-                        cutNameTerms++;
-                        break;
-                    default:
-                        break pathLoop;
-                }
-            }
-            /* eslint-enable block-scoped-var */
-
-            basePath.length = baseLen - cutBaseTerms;
-            namePath = namePath.slice(cutNameTerms);
-
-            return basePath.concat(namePath).join('/');
+        if (id.indexOf('.') !== 0) {
+            return id;
         }
 
-        return id;
+        var basePath = baseId.split('/').slice(0, -1); // remove last
+        var parts = basePath.concat(id.split('/'));
+
+        var res = [];
+        for (var i = 0; i < parts.length; i++) {
+            var p = parts[i];
+
+            // ignore empty parts
+            if (!p || p === '.') {
+                continue;
+            }
+
+            if (p === '..') {
+                if (res.length && res[res.length - 1] !== '..') {
+                    res.pop();
+                } else { // allow above root
+                    res.push('..');
+                }
+            } else {
+                res.push(p);
+            }
+        }
+        return res.join('/');
     }
 
     /**


### PR DESCRIPTION
「测试用例」

====id: "../../base/class" baseId: "../../lib/log"===

old: "../base/class"

new: "../../../base/class"

====id: "../../lib/jquery" baseId: "../src/main"===

old: "lib/jquery"

new: "../../lib/jquery"